### PR TITLE
chore: error-seo plugin を useSiteConfig 化 + 経緯コメント追記

### DIFF
--- a/app/plugins/error-seo.ts
+++ b/app/plugins/error-seo.ts
@@ -1,9 +1,14 @@
+// error.vue の setup 内で useSeoMeta を呼ぶと、直接 URL で 404 にアクセスされた際に
+// unhead コンテキストにバインドされず title が反映されないケースがあるため plugin 化。
+// また nuxt-seo-utils の titleTemplate はエラー時に siteName suffix を付けない
+// (`err ? "%s" : "%s %separator %siteName"`) ので、ここで明示的に付与する。
 export default defineNuxtPlugin({
   name: 'error-seo',
   setup() {
     const err = useError();
+    const site = useSiteConfig();
     useHead({
-      title: () => err.value ? `${err.value.statusCode} | ryuhei373.dev` : null,
+      title: () => err.value ? `${err.value.statusCode} | ${site.name}` : null,
     });
   },
 });


### PR DESCRIPTION
## Summary
- PR #100 のレビューで、`app/plugins/error-seo.ts` にハードコードされていた `"ryuhei373.dev"` を `useSiteConfig().name` に置き換え、`nuxt.config.ts` の `site.name` と二重管理にならないよう修正
- この plugin がなぜ存在するか（error.vue setup では unhead に反映されないケースがある / nuxt-seo-utils の `titleTemplate` がエラー時に siteName を付けない）を数行のコメントで明記

## 実装方針の妥当性検証
レビュー観点で「error.vue の `useSeoMeta` のみで十分では？」という疑問があったので、ローカル `nr generate && nr preview`（wrangler dev）で直接 URL 404 アクセスを検証：

| 方式 | 直接 URL 404 での title |
|---|---|
| error.vue の `useSeoMeta({ title })` のみ | 空 (`""`) |
| plugin の `useHead(() => err.value ? ... : null)` | `404 \| ryuhei373.dev` |

Nuxt の error 経路では `vueApp.config.errorHandler` → `nuxt.payload.error` → `useError()` 経由で error.vue が描画されるライフサイクルになり、error.vue setup 内の `useSeoMeta` は unhead に bind されず silent no-op に。一方 plugin は `applyPlugins()` 内で Nuxt context 込みで実行されるため、reactive な `useHead` 登録が error 発生時に確実に効く。よって現在の plugin 方式が適切と確認。

## Test plan
- [x] `/`（直接アクセス）: title = `ryuhei373.dev`
- [x] `/blog/2026-04-04`（直接アクセス）: title = `2026年3月まとめ | ryuhei373.dev`
- [x] `/archive/2024`（直接アクセス）: title = `2024 | ryuhei373.dev`
- [x] `/nonexistent`（直接アクセス・dev）: title = `404 | ryuhei373.dev`
- [x] `/nonexistent`（直接アクセス・wrangler preview）: title = `404 | ryuhei373.dev`
- [x] 404 → 「トップに戻る」クリック: title が `ryuhei373.dev` に切り替わる（plugin の `null` で clear）
- [x] `/robots.txt`, `/sitemap.xml`, `/rss.xml`: plugin による副作用なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)