### PR TITLE
fix: header/footer の左右余白ズレを修正 + Colophon 文言整理

### DIFF
--- a/app/components/AppFooter.vue
+++ b/app/components/AppFooter.vue
@@ -19,11 +19,10 @@ const connectLinks = [
   <UFooter
     :ui="{
       root: 'border-t border-muted mt-16',
-      container: 'max-w-(--ui-container) mx-auto px-6',
     }"
   >
     <template #top>
-      <div class="max-w-(--ui-container) mx-auto px-6 grid grid-cols-1 md:grid-cols-3 gap-8 py-12">
+      <UContainer class="grid grid-cols-1 md:grid-cols-3 gap-8 py-12">
         <div>
           <h2 class="text-sm font-semibold text-highlighted mb-3">
             Archive
@@ -115,7 +114,7 @@ const connectLinks = [
             </li>
           </ul>
         </div>
-      </div>
+      </UContainer>
     </template>
   </UFooter>
 </template>

--- a/app/components/AppFooter.vue
+++ b/app/components/AppFooter.vue
@@ -91,7 +91,7 @@ const connectLinks = [
             <li>Built with Nuxt 4 / Nuxt UI / Nuxt Content</li>
             <li>Hosted on Cloudflare Workers</li>
             <li>
-              Color scheme:
+              Themed with
               <ULink
                 to="https://stephango.com/flexoki"
                 target="_blank"
@@ -100,7 +100,6 @@ const connectLinks = [
               >
                 flexoki
               </ULink>
-              by Steph Ango
             </li>
             <li>
               <ULink

--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -4,7 +4,6 @@
     title="ryuhei373.dev"
     :toggle="false"
     :ui="{
-      container: 'flex items-center justify-between gap-3 h-full max-w-(--ui-container) mx-auto px-6',
       title: 'items-center gap-3 text-primary hover:text-secondary',
     }"
   >


### PR DESCRIPTION
## Summary
- Header と Footer `#top` の content 左右位置が lg+ breakpoint で 8px ズレていた問題を修正
- `:ui="{ container: ... }"` の上書きを削除し、Nuxt UI の UContainer デフォルト（`w-full max-w-(--ui-container) mx-auto px-4 sm:px-6 lg:px-8`）に乗せる形にリファクタ
- Footer `#top` slot 内の `<div>` を `<UContainer>` に差し替え、Header / Footer / Footer#top すべてで同一 container を使用
- ついでに Colophon の文言を前置詞パターンで統一（`Color scheme: flexoki by Steph Ango` → `Themed with flexoki`）

## 背景
過去のコミット `875dc89` で「タブレット幅でも余白を入れたい」という意図で `px-6` 上書きを入れたが、Nuxt UI の `lg:px-8` とマージされ lg+ で 32px になっていた。一方 Footer `#top` は UContainer を通らない自前 `<div>` で `px-6` のまま、という非対称から 8px ズレが発生していた。

## Test plan
- [x] desktop (viewport 1512): Header content 212↔1300, Footer content 212↔1300 で一致
- [x] 同一 UContainer ベースでレスポンシブ動作も揃う（24px → 32px @ lg）
- [x] Colophon 4 項目が前置詞パターンで整列（Built with / Hosted on / Themed with / Source on）

🤖 Generated with [Claude Code](https://claude.com/claude-code)