### PR TITLE
chore: dev の警告ノイズ削減（og-image zeroRuntime + vite optimizeDeps）

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -70,6 +70,16 @@ export default defineNuxtConfig({
     },
   },
 
+  vite: {
+    optimizeDeps: {
+      include: [
+        '@vue/devtools-core',
+        '@vue/devtools-kit',
+        '@unhead/schema-org/vue',
+      ],
+    },
+  },
+
   eslint: {
     config: {
       stylistic: {
@@ -82,6 +92,10 @@ export default defineNuxtConfig({
     clientBundle: {
       scan: true,
     },
+  },
+
+  ogImage: {
+    zeroRuntime: true,
   },
 
   seo: {


### PR DESCRIPTION
## Summary
`nr dev` 起動時に出ていた 2 種類の警告を抑える。

### 1. `[@nuxtjs/og-image] OG image URLs are not signed`
- `ogImage.zeroRuntime: true` を設定
- 本サイトは `nr generate` で全 OG image を `.output/public/_og/s/` に prerender し、Cloudflare Workers Assets から serve する運用なので runtime 生成を無効化しても影響なし
- 副次的に署名シークレット管理も不要に

### 2. `Vite discovered new dependencies at runtime: @vue/devtools-core, @vue/devtools-kit, @unhead/schema-org/vue`
- `vite.optimizeDeps.include` に 3 パッケージを追加して pre-bundle 化
- dev 初回アクセス時のページリロードが減る
- prod ビルドには影響なし

## Test plan
- [x] `nr dev` 起動後、og-image 署名警告が出ない
- [x] `nr dev` 起動後、Vite pre-bundle 警告が出ない
- [x] OG image は従来通り生成される（`/_og/s/c_Site.png` が 200 / 正しい PNG を返す）
- [x] サイト全体の動作に影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)