### PR TITLE
fix: Lighthouse a11y 100 + CSS inline 化で render-block 解消 + 記事リストの構造整理

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -22,7 +22,7 @@ useHead({
 <template>
   <UApp>
     <AppHeader />
-    <UContainer>
+    <UContainer as="main">
       <div class="max-w-2xl mx-auto">
         <NuxtPage />
       </div>

--- a/app/components/AppFooter.vue
+++ b/app/components/AppFooter.vue
@@ -95,7 +95,7 @@ const connectLinks = [
               <ULink
                 to="https://stephango.com/flexoki"
                 target="_blank"
-                class="hover:text-secondary"
+                class="underline hover:text-secondary"
                 inactive-class="text-primary"
               >
                 flexoki

--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -8,7 +8,10 @@
     }"
   >
     <template #title>
-      <UAvatar src="https://github.com/ryuhei373.png" />
+      <UAvatar
+        src="https://github.com/ryuhei373.png"
+        alt="ryuhei373 のアバター"
+      />
       <span>ryuhei373.dev</span>
     </template>
     <template #right>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -4,45 +4,41 @@ const { data: articles } = await useAsyncData(path, () => queryCollection('blog'
 </script>
 
 <template>
-  <ul class="relative flex flex-col list-none p-0 m-0 *:not-last:after:absolute *:not-last:after:inset-x-1 *:not-last:after:bottom-0 *:not-last:after:bg-border *:not-last:after:h-px">
-    <li
+  <UBlogPosts orientation="vertical">
+    <UBlogPost
       v-for="article in articles"
       :key="article.path"
-      class="relative"
+      variant="naked"
+      orientation="vertical"
     >
-      <UBlogPost
-        variant="naked"
-        orientation="vertical"
-      >
-        <template #body>
-          <ULink
-            :to="article.path"
-            class="block py-8 hover:text-secondary group"
-            inactive-class="text-primary"
-          >
-            <h2 class="text-2xl font-bold text-highlighted">
-              {{ article.title }}
-            </h2>
-            <div class="flex items-baseline flex-wrap gap-x-4 gap-y-1 mb-5">
-              <PostedDate :created-at="article.createdAt" />
-              <ArticleTags
-                v-if="article.tags?.length"
-                :tags="article.tags"
+      <template #body>
+        <ULink
+          :to="article.path"
+          class="block hover:text-secondary group"
+          inactive-class="text-primary"
+        >
+          <h2 class="text-2xl font-bold text-highlighted">
+            {{ article.title }}
+          </h2>
+          <div class="flex items-baseline flex-wrap gap-x-4 gap-y-1 mb-5">
+            <PostedDate :created-at="article.createdAt" />
+            <ArticleTags
+              v-if="article.tags?.length"
+              :tags="article.tags"
+            />
+          </div>
+          <p class="text-sm/relaxed text-default mb-5">{{ article.description }}</p>
+          <div class="flex justify-end">
+            <div class="group-hover:underline inline-flex items-center gap-1">
+              Read More
+              <UIcon
+                name="i-ri-arrow-right-s-line"
+                class="w-4 h-4"
               />
             </div>
-            <p class="text-sm/relaxed text-default mb-5">{{ article.description }}</p>
-            <div class="flex justify-end">
-              <div class="group-hover:underline inline-flex items-center gap-1">
-                Read More
-                <UIcon
-                  name="i-ri-arrow-right-s-line"
-                  class="w-4 h-4"
-                />
-              </div>
-            </div>
-          </ULink>
-        </template>
-      </UBlogPost>
-    </li>
-  </ul>
+          </div>
+        </ULink>
+      </template>
+    </UBlogPost>
+  </UBlogPosts>
 </template>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -4,12 +4,16 @@ const { data: articles } = await useAsyncData(path, () => queryCollection('blog'
 </script>
 
 <template>
-  <UBlogPosts orientation="vertical">
+  <UBlogPosts
+    orientation="vertical"
+    :ui="{ base: 'flex flex-col divide-y divide-default' }"
+  >
     <UBlogPost
       v-for="article in articles"
       :key="article.path"
       variant="naked"
       orientation="vertical"
+      class="py-8"
     >
       <template #body>
         <ULink

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -4,41 +4,45 @@ const { data: articles } = await useAsyncData(path, () => queryCollection('blog'
 </script>
 
 <template>
-  <UPageList divide>
-    <UBlogPost
+  <ul class="relative flex flex-col list-none p-0 m-0 *:not-last:after:absolute *:not-last:after:inset-x-1 *:not-last:after:bottom-0 *:not-last:after:bg-border *:not-last:after:h-px">
+    <li
       v-for="article in articles"
       :key="article.path"
-      variant="naked"
-      orientation="vertical"
+      class="relative"
     >
-      <template #body>
-        <ULink
-          :to="article.path"
-          class="block py-8 hover:text-secondary group"
-          inactive-class="text-primary"
-        >
-          <h2 class="text-2xl font-bold text-highlighted">
-            {{ article.title }}
-          </h2>
-          <div class="flex items-baseline flex-wrap gap-x-4 gap-y-1 mb-5">
-            <PostedDate :created-at="article.createdAt" />
-            <ArticleTags
-              v-if="article.tags?.length"
-              :tags="article.tags"
-            />
-          </div>
-          <p class="text-sm/relaxed text-default mb-5">{{ article.description }}</p>
-          <div class="flex justify-end">
-            <div class="group-hover:underline inline-flex items-center gap-1">
-              Read More
-              <UIcon
-                name="i-ri-arrow-right-s-line"
-                class="w-4 h-4"
+      <UBlogPost
+        variant="naked"
+        orientation="vertical"
+      >
+        <template #body>
+          <ULink
+            :to="article.path"
+            class="block py-8 hover:text-secondary group"
+            inactive-class="text-primary"
+          >
+            <h2 class="text-2xl font-bold text-highlighted">
+              {{ article.title }}
+            </h2>
+            <div class="flex items-baseline flex-wrap gap-x-4 gap-y-1 mb-5">
+              <PostedDate :created-at="article.createdAt" />
+              <ArticleTags
+                v-if="article.tags?.length"
+                :tags="article.tags"
               />
             </div>
-          </div>
-        </ULink>
-      </template>
-    </UBlogPost>
-  </UPageList>
+            <p class="text-sm/relaxed text-default mb-5">{{ article.description }}</p>
+            <div class="flex justify-end">
+              <div class="group-hover:underline inline-flex items-center gap-1">
+                Read More
+                <UIcon
+                  name="i-ri-arrow-right-s-line"
+                  class="w-4 h-4"
+                />
+              </div>
+            </div>
+          </ULink>
+        </template>
+      </UBlogPost>
+    </li>
+  </ul>
 </template>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -6,19 +6,18 @@ const { data: articles } = await useAsyncData(path, () => queryCollection('blog'
 <template>
   <UBlogPosts
     orientation="vertical"
-    :ui="{ base: 'flex flex-col divide-y divide-default' }"
+    :ui="{ base: 'flex flex-col gap-0 lg:gap-y-0 divide-y divide-default' }"
   >
     <UBlogPost
       v-for="article in articles"
       :key="article.path"
       variant="naked"
       orientation="vertical"
-      class="py-8"
     >
       <template #body>
         <ULink
           :to="article.path"
-          class="block hover:text-secondary group"
+          class="block py-8 hover:text-secondary group"
           inactive-class="text-primary"
         >
           <h2 class="text-2xl font-bold text-highlighted">

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -8,40 +8,36 @@ const { data: articles } = await useAsyncData(path, () => queryCollection('blog'
     orientation="vertical"
     :ui="{ base: 'flex flex-col gap-0 lg:gap-y-0 divide-y divide-default' }"
   >
-    <UBlogPost
+    <article
       v-for="article in articles"
       :key="article.path"
-      variant="naked"
-      orientation="vertical"
     >
-      <template #body>
-        <ULink
-          :to="article.path"
-          class="block py-8 hover:text-secondary group"
-          inactive-class="text-primary"
-        >
-          <h2 class="text-2xl font-bold text-highlighted">
-            {{ article.title }}
-          </h2>
-          <div class="flex items-baseline flex-wrap gap-x-4 gap-y-1 mb-5">
-            <PostedDate :created-at="article.createdAt" />
-            <ArticleTags
-              v-if="article.tags?.length"
-              :tags="article.tags"
+      <ULink
+        :to="article.path"
+        class="block py-8 hover:text-secondary group"
+        inactive-class="text-primary"
+      >
+        <h2 class="text-2xl font-bold text-highlighted">
+          {{ article.title }}
+        </h2>
+        <div class="flex items-baseline flex-wrap gap-x-4 gap-y-1 mb-5">
+          <PostedDate :created-at="article.createdAt" />
+          <ArticleTags
+            v-if="article.tags?.length"
+            :tags="article.tags"
+          />
+        </div>
+        <p class="text-sm/relaxed text-default mb-5">{{ article.description }}</p>
+        <div class="flex justify-end">
+          <div class="group-hover:underline inline-flex items-center gap-1">
+            Read More
+            <UIcon
+              name="i-ri-arrow-right-s-line"
+              class="w-4 h-4"
             />
           </div>
-          <p class="text-sm/relaxed text-default mb-5">{{ article.description }}</p>
-          <div class="flex justify-end">
-            <div class="group-hover:underline inline-flex items-center gap-1">
-              Read More
-              <UIcon
-                name="i-ri-arrow-right-s-line"
-                class="w-4 h-4"
-              />
-            </div>
-          </div>
-        </ULink>
-      </template>
-    </UBlogPost>
+        </div>
+      </ULink>
+    </article>
   </UBlogPosts>
 </template>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -62,6 +62,10 @@ export default defineNuxtConfig({
     },
   },
 
+  features: {
+    inlineStyles: true,
+  },
+
   compatibilityDate: '2024-09-03',
 
   nitro: {


### PR DESCRIPTION
## Summary
Lighthouse で検出された a11y 失敗 4 件と、本番 mobile での CSS render-blocking を解消。副次的に SEO も上がる見込み。加えて記事一覧の構造を整理して、Nuxt UI 由来のカード用 css との摩擦を除去。

## 修正内容

### a11y（4 件 → 0 件）

| Audit | 対象 | 対応 |
|---|---|---|
| `image-alt` | AppHeader の UAvatar | `alt="ryuhei373 のアバター"` 追加 |
| `landmark-one-main` | app.vue の UContainer | `as="main"` 追加 |
| `aria-required-children` | 記事一覧の `<div role="list">` | UPageList（`role="list"` hardcode）と UBlogPost（`<article>`）の組み合わせが ARIA 違反だったので、UBlogPosts + native `<article>` に置換 |
| `link-in-text-block` | Footer Colophon の flexoki リンク | `underline` 追加（text-primary vs text-muted が contrast 1.05:1 で色以外の差別化が必要） |

副次効果：SEO スコアも image-alt 連動で上がる見込み（prod で要確認）。

### 記事一覧の構造整理

旧: `<UPageList divide>` + `<UBlogPost>`
- UPageList の `role="list"` に対し UBlogPost の `<article>` が ARIA 違反
- UBlogPost は variant="naked" + #body slot で中身を完全自作しており、実質 `<article>` タグだけを使っていた
- UBlogPost のカード用 css（rounded-lg / overflow-hidden 等）と divider デザインの相性が悪い

新: `<UBlogPosts>` + native `<article>`
- UBlogPosts は role 衝突なし（単なる `<div>` wrapper）
- native `<article>` で Nuxt UI のカード css ノイズを排除
- divide-y が rounded-lg の影響を受けずにまっすぐ引かれる

### パフォーマンス（render-block 解消）

`features.inlineStyles: true` を追加。prod ビルドで entry CSS が HTML に inline される。

Lighthouse モバイル計測（Slow 4G / 4x CPU throttling）時点で：
- `/_nuxt/entry.CekJrBXJ.css`（render-blocking）が **LCP 1255ms のうち ~586ms** を占めていた
- 本対応で CSS fetch 往復が消え、理論上 **LCP ~670ms まで短縮**見込み
- HTML は ~42KB → ~254KB に増える（CSS inline ぶん）、compressed では軽微な増

## Test plan
- [x] dev lighthouse: Accessibility 100 / Best Practices 100（a11y 失敗 0）
- [x] 記事一覧の divider が直線で表示（rounded 影響なし）
- [x] 記事一覧の h2 位置が従前と同等（上から ~128, 332, 536, 762 px）
- [x] main ランドマークが存在（`<main>`）
- [x] prod ビルドで `entry.*.css` が `.output/public/_nuxt/` から消え、HTML に inline されている
- [ ] 本番反映後に OGP / Lighthouse 再測で LCP 改善確認（ユーザー側）

🤖 Generated with [Claude Code](https://claude.com/claude-code)