### PR TITLE
fix: features.inlineStyles を無効化（dark mode 切り替えを破壊していたため）

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -62,10 +62,6 @@ export default defineNuxtConfig({
     },
   },
 
-  features: {
-    inlineStyles: true,
-  },
-
   compatibilityDate: '2024-09-03',
 
   nitro: {


### PR DESCRIPTION
## Summary
**本番のダークモード切り替えが壊れているため、#105 で導入した `features.inlineStyles: true` を revert する hotfix**。

## 症状
本番 / ブランチプレビュー共に、ダークモード切り替えボタンを押すと html に `.dark` クラスは付くが、CSS が適用されず見た目がライトのままになる。

## 根本原因

Nuxt UI は body に `@apply antialiased text-default bg-default scheme-light dark:scheme-dark` を適用しており、Tailwind CSS v4 はこれを本来：

```css
body:where(.dark, .dark *) { color-scheme: dark; }
```

にコンパイルする。`.dark *` の部分が「`.dark` 要素の子孫」にマッチするので、`html.dark > body` のケースで body に `color-scheme: dark` が当たり、`--ui-bg: light-dark(light, dark)` が dark を返す。

しかし `features.inlineStyles: true` を有効にすると、生成される CSS が：

```css
body:where(.dark) { color-scheme: dark; }
```

と `.dark *` 部分が消える。この selector は「body 自身が `.dark` クラスを持つ」場合にしかマッチしないが、`@nuxtjs/color-mode` は html に `.dark` を付けるので一致せず、body の color-scheme が `light` のまま → light-dark() が light を返す → 見た目がライトのまま、となる。

### 実測比較

| 設定 | body の color-scheme 関連 rule |
|---|---|
| `features.inlineStyles: false` (従来 / 外部 CSS) | `body:where(.dark,.dark *) { color-scheme: dark; }` ✅ |
| `features.inlineStyles: true` (壊れた版) | `body:where(.dark) { color-scheme: dark; }` ❌ |

おそらく Nuxt の SSRStylesPlugin が `?inline&used` クエリ経由で CSS を処理する過程で、どこかの最適化段階が `:where(.dark, .dark *)` を `:where(.dark)` に誤って単純化している。

関連 issue は nuxt/nuxt トラッカーで探したが直接合致するものはなし（search keywords: `features.inlineStyles` / `inlineStyles dark` / `?inline&used where` など）。最小再現が作れれば上流に issue 登録する価値あり。

## Trade-off

- 失うもの: モバイル Slow 4G での LCP 約 **-427ms** の改善（PR #105）
- 得るもの: ダークモード切り替えの正常動作

代替手段（critical CSS 抽出 / CF Early Hints / 手動 `<style>` inject 等）は別 PR で検討する。

## Test plan
- [x] `nr generate` で `entry.*.css` が `.output/public/_nuxt/` に生成される（inline されない）
- [ ] デプロイ後、本番 / プレビュー共にダークモード切り替えが機能する（bodyBg が dark に変わる）

🤖 Generated with [Claude Code](https://claude.com/claude-code)