### PR TITLE
feat: フッターに bg-muted を敷きリンク装飾を underline で統一

### DIFF
--- a/app/components/AppFooter.vue
+++ b/app/components/AppFooter.vue
@@ -18,7 +18,7 @@ const connectLinks = [
 <template>
   <UFooter
     :ui="{
-      root: 'border-t border-muted mt-16',
+      root: 'border-t border-muted mt-16 bg-muted',
     }"
   >
     <template #top>
@@ -34,7 +34,7 @@ const connectLinks = [
             >
               <ULink
                 :to="`/archive/${year}/`"
-                class="text-sm text-muted hover:text-secondary tabular-nums"
+                class="text-sm text-muted hover:text-secondary underline tabular-nums"
                 active-class=""
                 inactive-class=""
               >
@@ -55,7 +55,7 @@ const connectLinks = [
               <ULink
                 :to="link.url"
                 target="_blank"
-                class="inline-flex items-center gap-2 text-sm text-muted hover:text-secondary"
+                class="inline-flex items-center gap-2 text-sm text-muted hover:text-secondary underline"
                 active-class=""
                 inactive-class=""
               >
@@ -70,7 +70,7 @@ const connectLinks = [
               <ULink
                 to="/rss.xml"
                 external
-                class="inline-flex items-center gap-2 text-sm text-muted hover:text-secondary"
+                class="inline-flex items-center gap-2 text-sm text-muted hover:text-secondary underline"
                 active-class=""
                 inactive-class=""
               >
@@ -96,7 +96,8 @@ const connectLinks = [
                 to="https://stephango.com/flexoki"
                 target="_blank"
                 class="underline hover:text-secondary"
-                inactive-class="text-primary"
+                active-class=""
+                inactive-class=""
               >
                 flexoki
               </ULink>
@@ -105,8 +106,9 @@ const connectLinks = [
               <ULink
                 to="https://github.com/ryuhei373/ryuhei373.dev"
                 target="_blank"
-                class="hover:text-secondary"
-                inactive-class="text-primary"
+                class="underline hover:text-secondary"
+                active-class=""
+                inactive-class=""
               >
                 Source on GitHub
               </ULink>


### PR DESCRIPTION
## Summary

- フッター全体に `bg-muted` を当て、本文と面で分離
- 全リンクに `underline` を付与し、Colophon の orange 着色（`inactive-class="text-primary"`）を撤廃
- 「装飾あり＝リンク／装飾なし＝非リンク」のルールを footer 全体で一貫させ、アクセシビリティを向上

## 背景

- フッターが本文と同色で単調だったため面分離を入れたい
- Archive/Connect は全項目リンクで text-muted、Colophon は同色の text-muted でも非リンクを含み、リンク識別が見た目で判別しづらかった
- 色相を増やす案も検討したが、Flexoki の単色 grading と一貫性を保つため見送り、underline で識別する方針に

## Test plan

- [ ] `nr dev` でフッターの背景が body と区別されることを確認
- [ ] Archive 年号・Connect ソーシャル・Colophon の各リンクに underline が表示される
- [ ] 非リンクのテキスト（"Built with..." / "Hosted on..."）には underline が出ない
- [ ] hover で text-secondary（orange）に変わる
- [ ] light/dark 両モードで視認性に問題がない

🤖 Generated with [Claude Code](https://claude.com/claude-code)