### PR TITLE
feat: ページ遷移と footer 周りの polish を追加

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -39,3 +39,24 @@
 * {
   text-decoration-thickness: 1px;
 }
+
+a {
+  transition: color 300ms ease;
+}
+
+.page-enter-active,
+.page-leave-active {
+  transition: opacity 150ms ease;
+}
+
+.page-enter-from,
+.page-leave-to {
+  opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/app/components/AppFooter.vue
+++ b/app/components/AppFooter.vue
@@ -18,7 +18,7 @@ const connectLinks = [
 <template>
   <UFooter
     :ui="{
-      root: 'border-t border-muted mt-16 bg-muted',
+      root: 'border-t border-default mt-16 bg-elevated',
     }"
   >
     <template #top>

--- a/app/pages/archive/[year].vue
+++ b/app/pages/archive/[year].vue
@@ -32,42 +32,44 @@ defineOgImage('Site');
 </script>
 
 <template>
-  <UPageHeader :title="year" />
-  <UPageList divide>
-    <UBlogPost
-      v-for="article in articles"
-      :key="article.path"
-      variant="naked"
-      orientation="vertical"
-    >
-      <template #body>
-        <ULink
-          :to="article.path"
-          class="block py-8 hover:text-secondary group"
-          inactive-class="text-primary"
-        >
-          <h2 class="text-2xl font-bold text-highlighted">
-            {{ article.title }}
-          </h2>
-          <div class="flex items-baseline flex-wrap gap-x-4 gap-y-1 mb-5">
-            <PostedDate :created-at="article.createdAt" />
-            <ArticleTags
-              v-if="article.tags?.length"
-              :tags="article.tags"
-            />
-          </div>
-          <p class="text-sm/relaxed text-default mb-5">{{ article.description }}</p>
-          <div class="flex justify-end">
-            <div class="group-hover:underline inline-flex items-center gap-1">
-              Read More
-              <UIcon
-                name="i-ri-arrow-right-s-line"
-                class="w-4 h-4"
+  <div>
+    <UPageHeader :title="year" />
+    <UPageList divide>
+      <UBlogPost
+        v-for="article in articles"
+        :key="article.path"
+        variant="naked"
+        orientation="vertical"
+      >
+        <template #body>
+          <ULink
+            :to="article.path"
+            class="block py-8 hover:text-secondary group"
+            inactive-class="text-primary"
+          >
+            <h2 class="text-2xl font-bold text-highlighted">
+              {{ article.title }}
+            </h2>
+            <div class="flex items-baseline flex-wrap gap-x-4 gap-y-1 mb-5">
+              <PostedDate :created-at="article.createdAt" />
+              <ArticleTags
+                v-if="article.tags?.length"
+                :tags="article.tags"
               />
             </div>
-          </div>
-        </ULink>
-      </template>
-    </UBlogPost>
-  </UPageList>
+            <p class="text-sm/relaxed text-default mb-5">{{ article.description }}</p>
+            <div class="flex justify-end">
+              <div class="underline inline-flex items-center gap-1">
+                Read More
+                <UIcon
+                  name="i-ri-arrow-right-s-line"
+                  class="w-4 h-4"
+                />
+              </div>
+            </div>
+          </ULink>
+        </template>
+      </UBlogPost>
+    </UPageList>
+  </div>
 </template>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -29,7 +29,7 @@ const { data: articles } = await useAsyncData(path, () => queryCollection('blog'
         </div>
         <p class="text-sm/relaxed text-default mb-5">{{ article.description }}</p>
         <div class="flex justify-end">
-          <div class="group-hover:underline inline-flex items-center gap-1">
+          <div class="underline inline-flex items-center gap-1">
             Read More
             <UIcon
               name="i-ri-arrow-right-s-line"

--- a/app/pages/tags/[tag].vue
+++ b/app/pages/tags/[tag].vue
@@ -33,42 +33,44 @@ defineOgImage('Site');
 </script>
 
 <template>
-  <UPageHeader :title="`#${displayName}`" />
-  <UPageList divide>
-    <UBlogPost
-      v-for="article in articles"
-      :key="article.path"
-      variant="naked"
-      orientation="vertical"
-    >
-      <template #body>
-        <ULink
-          :to="article.path"
-          class="block py-8 hover:text-secondary group"
-          inactive-class="text-primary"
-        >
-          <h2 class="text-2xl font-bold text-highlighted">
-            {{ article.title }}
-          </h2>
-          <div class="flex items-baseline flex-wrap gap-x-4 gap-y-1 mb-5">
-            <PostedDate :created-at="article.createdAt" />
-            <ArticleTags
-              v-if="article.tags?.length"
-              :tags="article.tags"
-            />
-          </div>
-          <p class="text-sm/relaxed text-default mb-5">{{ article.description }}</p>
-          <div class="flex justify-end">
-            <div class="group-hover:underline inline-flex items-center gap-1">
-              Read More
-              <UIcon
-                name="i-ri-arrow-right-s-line"
-                class="w-4 h-4"
+  <div>
+    <UPageHeader :title="`#${displayName}`" />
+    <UPageList divide>
+      <UBlogPost
+        v-for="article in articles"
+        :key="article.path"
+        variant="naked"
+        orientation="vertical"
+      >
+        <template #body>
+          <ULink
+            :to="article.path"
+            class="block py-8 hover:text-secondary group"
+            inactive-class="text-primary"
+          >
+            <h2 class="text-2xl font-bold text-highlighted">
+              {{ article.title }}
+            </h2>
+            <div class="flex items-baseline flex-wrap gap-x-4 gap-y-1 mb-5">
+              <PostedDate :created-at="article.createdAt" />
+              <ArticleTags
+                v-if="article.tags?.length"
+                :tags="article.tags"
               />
             </div>
-          </div>
-        </ULink>
-      </template>
-    </UBlogPost>
-  </UPageList>
+            <p class="text-sm/relaxed text-default mb-5">{{ article.description }}</p>
+            <div class="flex justify-end">
+              <div class="underline inline-flex items-center gap-1">
+                Read More
+                <UIcon
+                  name="i-ri-arrow-right-s-line"
+                  class="w-4 h-4"
+                />
+              </div>
+            </div>
+          </ULink>
+        </template>
+      </UBlogPost>
+    </UPageList>
+  </div>
 </template>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -18,6 +18,7 @@ export default defineNuxtConfig({
         prefix: 'og: <https://ogp.me/ns#>',
       },
     },
+    pageTransition: { name: 'page', mode: 'out-in' },
   },
 
   css: ['~/assets/css/main.css'],


### PR DESCRIPTION
## Summary

- ページ遷移に 150ms cross-fade を追加（記事リスト → 記事詳細などの遷移でフェード）
- リンク hover の色変化を 300ms ease に（snap → 滑らかに）
- 記事カードの Read More を常時 underline 表示に変更（hover 切替を撤廃して affordance を統一）
- footer 背景を `bg-elevated` に変更（本文との面分離を強化）
- footer の border 色を `border-default` に統一（header と揃えてサイトの上下対称性）
- `prefers-reduced-motion: reduce` を尊重するガードを追加

## 背景

frontend-design スキルで「単色すぎるサイト」のデザイン検討。色の追加（accent hue）は情報量に対してオーバーと判断して見送り、代わりに以下の方向で改修：

- **motion**: 色を増やさずに「滑らかさ」を加える方向。dark mode toggle 時の全体 color transition は light-dark() 関数の都合で transition が効かないため見送り、page transition と link hover に絞った。
- **footer 面分離**: bg-muted では本文との差が弱かったため bg-elevated に。
- **affordance 一貫性**: Read More を hover 出現から常時表示に。「装飾あり = リンク／クリック可能」のサイトルールを強化。

## Test plan

- [ ] `nr dev` で各ページを訪問して page transition の cross-fade が効くことを確認
- [ ] 記事一覧 → 記事詳細 → 戻る で遷移がスムーズに見える
- [ ] フッター・本文のリンク hover で色が 300ms フェードする
- [ ] 記事カードの Read More に常時 underline がついている
- [ ] フッター背景が body と区別できる（light/dark 両方）
- [ ] header / footer のボーダーが同色
- [ ] OS の「視差効果を減らす」設定で motion が無効化される

🤖 Generated with [Claude Code](https://claude.com/claude-code)