### PR TITLE
fix: footer の Archive リンクから末尾スラッシュを削除

### DIFF
--- a/app/components/AppFooter.vue
+++ b/app/components/AppFooter.vue
@@ -33,7 +33,7 @@ const connectLinks = [
               :key="year"
             >
               <ULink
-                :to="`/archive/${year}/`"
+                :to="`/archive/${year}`"
                 class="text-sm text-muted hover:text-secondary underline tabular-nums"
                 active-class=""
                 inactive-class=""


### PR DESCRIPTION
## Summary
- `AppFooter.vue` の Archive リンクが `/archive/${year}/` と末尾スラッシュ付きで書かれていたのを `/archive/${year}` に修正。
- 内部リンクからの不要なリダイレクト発生を解消し、Nuxt Link Checker の警告も解消する。

## 背景
- サイト内のルートは trailing slash なしで生成されているが、footer の Archive リンクのみ末尾スラッシュ付きで指していた。
- Cloudflare Workers Static Assets の `html_handling: "drop-trailing-slash"` 設定により実際のアクセス自体はリダイレクトで救済されていたが、毎回リダイレクトが挟まる状態だった。
- 全ページに footer がレンダリングされるため、ビルド時に 19 ページ × 3 リンクの warning が出ていた。

## Test plan
- [ ] `nr generate` を再実行し、Nuxt Link Checker の `/archive/...` に関する trailing-slash warning が消えていることを確認
- [ ] footer から各 Archive ページにリダイレクトなしで遷移できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)