### PR TITLE
fix: タグリンクの末尾スラッシュと og: prefix 値を修正

### DIFF
--- a/app/components/ArticleTags.vue
+++ b/app/components/ArticleTags.vue
@@ -24,7 +24,7 @@ defineProps({
     >
       <ULink
         v-if="linked"
-        :to="`/tags/${tag}/`"
+        :to="`/tags/${tag}`"
         class="text-muted text-sm hover:text-primary"
         active-class=""
         inactive-class=""

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -14,7 +14,7 @@ export default defineNuxtConfig({
     head: {
       htmlAttrs: {
         lang: 'ja',
-        prefix: 'og: <https://ogp.me/ns#>',
+        prefix: 'og: https://ogp.me/ns#',
       },
     },
     pageTransition: { name: 'page', mode: 'out-in' },


### PR DESCRIPTION
## Summary

`/code-review` で検出した 2 件を修正。

- **タグリンクの末尾スラッシュを削除** (`app/components/ArticleTags.vue`)
  - `:to="\`/tags/${tag}/\`"` → `:to="\`/tags/${tag}\`"`
  - sitemap / AppFooter など他箇所は末尾スラッシュなしで一貫。Wrangler の `assets.html_handling: "drop-trailing-slash"` でタグクリックごとに 308 redirect が発生していた
  - AGENTS.md 「末尾スラッシュ問題 — 過去に踏んでいる」に該当
- **`og:` prefix の山カッコを削除** (`nuxt.config.ts`)
  - `'og: <https://ogp.me/ns#>'` → `'og: https://ogp.me/ns#'`
  - 山カッコは RDFa prefix 構文として不正。`<html prefix="og: <https://ogp.me/ns#>">` という壊れた属性値を出力していた

## Test plan

- [x] `nr lint` が通る（lefthook pre-commit で確認済み）
- [x] dev で `<html prefix>` が `og: https://ogp.me/ns#` で出力されること（chrome-devtools-mcp で確認済み）
- [x] dev で記事ページのタグリンク `href` が `/tags/<slug>`（末尾スラッシュなし）で出力され、リンク先 `/tags/<slug>` が直接ロードされること（chrome-devtools-mcp で確認済み）
- [ ] 本番デプロイ後、`/tags/<slug>` クリック時に 308 redirect が発生しないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)